### PR TITLE
Bugfix for SCT-1037

### DIFF
--- a/lib/kb_Msuite/Utils/OutputBuilder.py
+++ b/lib/kb_Msuite/Utils/OutputBuilder.py
@@ -63,7 +63,14 @@ class OutputBuilder(object):
 
         # move plots we need into the html directory
         plot_name = 'bin_qa_plot.png'
-        shutil.copy(os.path.join(self.plots_dir, plot_name), os.path.join(html_dir, plot_name))
+        plot_path = os.path.join(self.plots_dir, plot_name)
+        if os.path.isfile(plot_path):
+            shutil.copy(plot_path, os.path.join(html_dir, plot_name))
+        else:
+            log(
+                'Warning: the bin_qa_plot image was not generated. '
+                'This is most likely due to image and file size.'
+            )
         self._copy_ref_dist_plots(self.plots_dir, html_dir)
 
         # write the html report to file

--- a/lib/kb_Msuite/Utils/OutputBuilder.py
+++ b/lib/kb_Msuite/Utils/OutputBuilder.py
@@ -64,7 +64,8 @@ class OutputBuilder(object):
         # move plots we need into the html directory
         plot_name = 'bin_qa_plot.png'
         plot_path = os.path.join(self.plots_dir, plot_name)
-        if os.path.isfile(plot_path):
+        plot_exists = os.path.isfile(plot_path)
+        if plot_exists:
             shutil.copy(plot_path, os.path.join(html_dir, plot_name))
         else:
             log(
@@ -84,10 +85,13 @@ class OutputBuilder(object):
         self._write_tabs(html)
 
         # include the single main summary figure
-        html.write('<div id="Plot" class="tabcontent">\n')
-        html.write('<img src="' + plot_name + '" width="90%" />\n')
-        html.write('<br><br><br>\n')
-        html.write('</div>\n')
+        if plot_exists:
+            html.write('<div id="Plot" class="tabcontent">\n')
+            html.write('<img src="' + plot_name + '" width="90%" />\n')
+            html.write('<br><br><br>\n')
+            html.write('</div>\n')
+        else:
+            html.write('<p>The Bin QA Plot was not generated.</p>')
 
         # print out the info table
         self.build_summary_table(html, html_dir)

--- a/lib/kb_Msuite/Utils/OutputBuilder.py
+++ b/lib/kb_Msuite/Utils/OutputBuilder.py
@@ -91,7 +91,11 @@ class OutputBuilder(object):
             html.write('<br><br><br>\n')
             html.write('</div>\n')
         else:
-            html.write('<p>The Bin QA Plot was not generated.</p>')
+            html.write(
+                '<p>Sorry, the Bin QA Plot was not generated. '
+                'This is likely due to having too many bins and '
+                'too large of an image size to properly render.</p>'
+            )
 
         # print out the info table
         self.build_summary_table(html, html_dir)


### PR DESCRIPTION
When a user runs checkM on a large number of bins (in this case, 240 fasta files), then the `checkm bin_qa_plot` command fails with an error message (but with exit code 0, so nothing is caught)

```
*******************************************************************************
 [CheckM - bin_qa_plot] Creating bar plot of bin quality.
*******************************************************************************

  Calculating AAI between multi-copy marker genes.
[Error] There are too many bins to plot.
The resulting plot would be 53652 pixels in height and the maximum allowed size is 32768.
Please reduce the number of bins to be plotted or decrease the DPI (--dpi).

  { Current stage: 0:00:00.142 || Total: 0:00:00.142 }
```

This PR just prevents the app from crashing so it can complete without that plot image. It doesn't fix the image generation. I can follow up with a PR that detects this error and reduces the DPI if people want it. 

https://kbase-jira.atlassian.net/browse/SCT-1037