### PR TITLE
Edits for ease of testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,76 +1,14 @@
-FROM kbase/sdkbase2:python
-
-# install cython that pysam likes
-RUN \
-  apt-get update && apt-get install -y build-essential wget \
-  && pip install --upgrade pip setuptools Cython==0.25
-
-###### CheckM installation
-#  Directions from https://github.com/Ecogenomics/CheckM/wiki/Installation#how-to-install-checkm
-#
-# CheckM requires the following programs to be added to your system path:
-#
-# HMMER (>=3.1b1)
-# prodigal (2.60 or >=2.6.1)
-# executable must be named prodigal and not prodigal.linux
-# pplacer (>=1.1)
-# guppy, which is part of the pplacer package, must also be on your system path
-# pplacer binaries can be found on the pplacer GitHub page
-
-# Install HMMER (>=3.1b1)
-WORKDIR /kb/module
-RUN \
-  curl http://eddylab.org/software/hmmer3/3.1b2/hmmer-3.1b2-linux-intel-x86_64.tar.gz > hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
-  tar -zxvf hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
-  ln -s hmmer-3.1b2-linux-intel-x86_64 hmmer && \
-  rm -f hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
-  cd hmmer && \
-  ./configure && \
-  make && make install && \
-  cd easel && make check && make install
-
-
-# Install Prodigal (2.60 or >=2.6.1)
-WORKDIR /kb/module
-RUN \
-  wget https://github.com/hyattpd/Prodigal/archive/v2.6.3.tar.gz && \
-  tar -zxvf v2.6.3.tar.gz && \
-  ln -s Prodigal-2.6.3 prodigal && \
-  rm -f v2.6.3.tar.gz && \
-  cd prodigal && \
-  make && \
-  cp prodigal /kb/deployment/bin/prodigal
-
-# Install Pplacer (>=1.1)
-WORKDIR /kb/module
-RUN \
-  wget https://github.com/matsen/pplacer/releases/download/v1.1.alpha19/pplacer-linux-v1.1.alpha19.zip && \
-  unzip pplacer-linux-v1.1.alpha19.zip && \
-  ln -s pplacer-Linux-v1.1.alpha19 pplacer && \
-  rm -f pplacer-linux-v1.1.alpha19.zip && \
-  rm -f pplacer-1.1.alpha19.tar.gz && \
-  cp -R pplacer-Linux-v1.1.alpha19 /kb/deployment/bin/pplacer
-
-ENV PATH "$PATH:/kb/deployment/bin/pplacer"
-
-# This will install CheckM and all other required Python libraries.
-RUN pip install numpy matplotlib==3.1.0 pysam scipy dendropy coverage checkm-genome \
-    && cp -R /miniconda/bin/checkm /kb/deployment/bin/CheckMBin \
-    && mkdir -p /data/checkm_data \
-    && mv /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG.orig \
-    && touch /data/DATA_CONFIG \
-    && cp /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG.orig /data/DATA_CONFIG \
-    && ln -sf /data/DATA_CONFIG /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG \
-    && chmod +rwx /data/DATA_CONFIG
+FROM ialarmedalien/kbase_checkm_base:latest
 
 COPY ./ /kb/module
 
 WORKDIR /kb/module
 
-RUN chmod -R a+rw /kb/module \
+RUN mkdir -p /kb/module/work/tmp/test_data \
+    && cp -r /kb/module/test/data/* /kb/module/work/tmp/test_data/ \
+    && chmod -R a+rw /kb/module \
     && make all \
-    && mkdir -p /kb/module/work/tmp/test_data \
-    && cp -r /kb/module/test/data/* /kb/module/work/tmp/test_data/
+    && rm -f /data/__READY__
 
 ENTRYPOINT [ "./scripts/entrypoint.sh" ]
 

--- a/Dockerfile_checkM
+++ b/Dockerfile_checkM
@@ -1,0 +1,66 @@
+FROM kbase/sdkbase2:python
+
+# base image with checkM installed to save time running tests on GitHub
+
+# install cython that pysam likes
+RUN \
+  apt-get update && apt-get install -y build-essential wget \
+  && pip install --upgrade pip setuptools Cython==0.25
+
+###### CheckM installation
+#  Directions from https://github.com/Ecogenomics/CheckM/wiki/Installation#how-to-install-checkm
+
+# CheckM requires the following programs to be added to your system path:
+#
+# HMMER (>=3.1b1)
+# prodigal (2.60 or >=2.6.1)
+# executable must be named prodigal and not prodigal.linux
+# pplacer (>=1.1)
+# guppy, which is part of the pplacer package, must also be on your system path
+# pplacer binaries can be found on the pplacer GitHub page
+
+# Install HMMER (>=3.1b1)
+WORKDIR /kb/module
+RUN \
+  curl http://eddylab.org/software/hmmer3/3.1b2/hmmer-3.1b2-linux-intel-x86_64.tar.gz > hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
+  tar -zxvf hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
+  ln -s hmmer-3.1b2-linux-intel-x86_64 hmmer && \
+  rm -f hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
+  cd hmmer && \
+  ./configure && \
+  make && make install && \
+  cd easel && make check && make install
+
+# Install Prodigal (2.60 or >=2.6.1)
+WORKDIR /kb/module
+RUN \
+  wget https://github.com/hyattpd/Prodigal/archive/v2.6.3.tar.gz && \
+  tar -zxvf v2.6.3.tar.gz && \
+  ln -s Prodigal-2.6.3 prodigal && \
+  rm -f v2.6.3.tar.gz && \
+  cd prodigal && \
+  make && \
+  cp prodigal /kb/deployment/bin/prodigal
+
+# Install Pplacer (>=1.1)
+WORKDIR /kb/module
+RUN \
+  wget https://github.com/matsen/pplacer/releases/download/v1.1.alpha19/pplacer-linux-v1.1.alpha19.zip && \
+  unzip pplacer-linux-v1.1.alpha19.zip && \
+  ln -s pplacer-Linux-v1.1.alpha19 pplacer && \
+  rm -f pplacer-linux-v1.1.alpha19.zip && \
+  rm -f pplacer-1.1.alpha19.tar.gz && \
+  cp -R pplacer-Linux-v1.1.alpha19 /kb/deployment/bin/pplacer
+
+ENV PATH "$PATH:/kb/deployment/bin/pplacer"
+
+# This will install CheckM and all other required Python libraries.
+RUN \
+    pip install numpy matplotlib==3.1.0 pysam scipy dendropy coverage checkm-genome \
+    && cp -R /miniconda/bin/checkm /kb/deployment/bin/CheckMBin \
+    && mkdir -p /data/checkm_data \
+    && mv /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG.orig \
+    && touch /data/DATA_CONFIG \
+    && cp /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG.orig /data/DATA_CONFIG \
+    && ln -sf /data/DATA_CONFIG /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG \
+    && chmod +rwx /data/DATA_CONFIG

--- a/Dockerfile_full
+++ b/Dockerfile_full
@@ -1,0 +1,87 @@
+FROM kbase/sdkbase2:python
+
+# install cython that pysam likes
+RUN \
+  apt-get update && apt-get install -y build-essential wget \
+  && pip install --upgrade pip setuptools Cython==0.25
+
+###### CheckM installation
+#  Directions from https://github.com/Ecogenomics/CheckM/wiki/Installation#how-to-install-checkm
+
+# CheckM requires the following programs to be added to your system path:
+#
+# HMMER (>=3.1b1)
+# prodigal (2.60 or >=2.6.1)
+# executable must be named prodigal and not prodigal.linux
+# pplacer (>=1.1)
+# guppy, which is part of the pplacer package, must also be on your system path
+# pplacer binaries can be found on the pplacer GitHub page
+
+# Install HMMER (>=3.1b1)
+WORKDIR /kb/module
+RUN \
+  curl http://eddylab.org/software/hmmer3/3.1b2/hmmer-3.1b2-linux-intel-x86_64.tar.gz > hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
+  tar -zxvf hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
+  ln -s hmmer-3.1b2-linux-intel-x86_64 hmmer && \
+  rm -f hmmer-3.1b2-linux-intel-x86_64.tar.gz && \
+  cd hmmer && \
+  ./configure && \
+  make && make install && \
+  cd easel && make check && make install
+
+
+# Install Prodigal (2.60 or >=2.6.1)
+WORKDIR /kb/module
+RUN \
+  wget https://github.com/hyattpd/Prodigal/archive/v2.6.3.tar.gz && \
+  tar -zxvf v2.6.3.tar.gz && \
+  ln -s Prodigal-2.6.3 prodigal && \
+  rm -f v2.6.3.tar.gz && \
+  cd prodigal && \
+  make && \
+  cp prodigal /kb/deployment/bin/prodigal
+
+# Install Pplacer (>=1.1)
+WORKDIR /kb/module
+RUN \
+  wget https://github.com/matsen/pplacer/releases/download/v1.1.alpha19/pplacer-linux-v1.1.alpha19.zip && \
+  unzip pplacer-linux-v1.1.alpha19.zip && \
+  ln -s pplacer-Linux-v1.1.alpha19 pplacer && \
+  rm -f pplacer-linux-v1.1.alpha19.zip && \
+  rm -f pplacer-1.1.alpha19.tar.gz && \
+  cp -R pplacer-Linux-v1.1.alpha19 /kb/deployment/bin/pplacer
+
+ENV PATH "$PATH:/kb/deployment/bin/pplacer"
+
+# This will install CheckM and all other required Python libraries.
+RUN \
+    pip3 install numpy \
+    && pip3 install matplotlib==3.1.0 \
+    && pip3 install pysam \
+    && pip3 install scipy \
+    && pip3 install dendropy \
+    && pip3 install coverage \
+    && pip3 install checkm-genome \
+    && cp -R /miniconda/bin/checkm /kb/deployment/bin/CheckMBin \
+    && mkdir -p /data/checkm_data \
+    && mv /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG.orig \
+    && touch /data/DATA_CONFIG \
+    && cp /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG.orig /data/DATA_CONFIG \
+    && ln -sf /data/DATA_CONFIG /miniconda/lib/python3.6/site-packages/checkm/DATA_CONFIG \
+    && chmod +rwx /data/DATA_CONFIG
+
+RUN apt-get install -y tree
+
+COPY ./ /kb/module
+
+WORKDIR /kb/module
+
+RUN mkdir -p /kb/module/work/tmp/test_data \
+    && cp -r /kb/module/test/data/* /kb/module/work/tmp/test_data/ \
+    && chmod -R a+rw /kb/module \
+    && make all \
+    && rm -f /data/__READY__
+
+ENTRYPOINT [ "./scripts/entrypoint.sh" ]
+
+CMD [ ]

--- a/kbase.yml
+++ b/kbase.yml
@@ -11,7 +11,7 @@ module-version:
     1.4.0
 
 owners:
-    [dylan, dparks, msneddon, tgu2, seanjungbluth]
+    [dylan, dparks, msneddon, tgu2, seanjungbluth, ialarmedalien]
 
 data-version:
     1.0

--- a/test/core_checkM_test.py
+++ b/test/core_checkM_test.py
@@ -226,7 +226,7 @@ class CoreCheckMTest(unittest.TestCase):
     def prep_assemblies(self):
         ''' prepare the assemblies and assembly set '''
 
-        assembly_list = TEST_DATA['assembly_list'][3:]
+        assembly_list = TEST_DATA['assembly_list'][0:3]
 
         # just load the test assembly and the dodgy contig assembly
         for assembly in assembly_list:
@@ -350,7 +350,7 @@ class CoreCheckMTest(unittest.TestCase):
 
         ''' add a couple of genomes and create a genome set '''
 
-        genome_list = TEST_DATA['genome_list'][3:]
+        genome_list = TEST_DATA['genome_list'][0:3]
 
         # upload a few genomes
         for genome in genome_list:
@@ -483,7 +483,7 @@ class CoreCheckMTest(unittest.TestCase):
         print ("=================================================================\n")
 
         # run checkM lineage_wf app on a single assembly
-        assembly = TEST_DATA['assembly_list'][3]
+        assembly = TEST_DATA['assembly_list'][1]
 
         input_ref = getattr(self, assembly['attr'])
         params = {
@@ -644,7 +644,7 @@ class CoreCheckMTest(unittest.TestCase):
 
         # run checkM lineage_wf app on a single genome
         # input_ref = self.genome_refs[0]
-        genome = TEST_DATA['genome_list'][3]
+        genome = TEST_DATA['genome_list'][1]
 
         input_ref = getattr(self, genome['attr'])
         params = {

--- a/test/core_checkM_test.py
+++ b/test/core_checkM_test.py
@@ -183,7 +183,7 @@ class CoreCheckMTest(unittest.TestCase):
 
         assembly_file_path = os.path.join(self.test_data_dir, "assemblies", assembly['path'])
         if not os.path.exists(assembly_file_path):
-            shutil.copy(os.path.join("data", "assemblies", assembly['path']), assembly_file_path)
+            shutil.copy(os.path.join(self.appdir, "test", "data", "assemblies", assembly['path']), assembly_file_path)
 
         saved_assembly = self.au.save_assembly_from_fasta({
             'file': {'path': assembly_file_path},
@@ -226,7 +226,7 @@ class CoreCheckMTest(unittest.TestCase):
     def prep_assemblies(self):
         ''' prepare the assemblies and assembly set '''
 
-        assembly_list = TEST_DATA['assembly_list'][0:3]
+        assembly_list = TEST_DATA['assembly_list']
 
         # just load the test assembly and the dodgy contig assembly
         for assembly in assembly_list:
@@ -241,7 +241,7 @@ class CoreCheckMTest(unittest.TestCase):
                         'ref':   getattr(self, a['attr']),
                         'label': a['name'],
                     }
-                    for a in assembly_list
+                    for a in assembly_list[0:3]
                 ],
             },
         ]
@@ -261,7 +261,7 @@ class CoreCheckMTest(unittest.TestCase):
             os.path.join(binned_contigs_path, 'bin.summary')
         ):
             shutil.rmtree(binned_contigs_path, ignore_errors=True)
-            shutil.copytree(os.path.join("data", bc['path']), binned_contigs_path)
+            shutil.copytree(os.path.join(self.appdir, "test", "data", bc['path']), binned_contigs_path)
 
         saved_object = self.mu.file_to_binned_contigs({
             'file_directory': binned_contigs_path,
@@ -298,7 +298,7 @@ class CoreCheckMTest(unittest.TestCase):
 
         genome_file_path = os.path.join(self.test_data_dir, genome['path'])
         if not os.path.exists(genome_file_path):
-            shutil.copy(os.path.join("data", "genomes", genome['path']), genome_file_path)
+            shutil.copy(os.path.join(self.appdir, "test", "data", "genomes", genome['path']), genome_file_path)
 
         genome_data = self.gfu.genbank_to_genome({
             'file': {'path': genome_file_path},

--- a/ui/narrative/methods/run_checkM_lineage_wf/spec.json
+++ b/ui/narrative/methods/run_checkM_lineage_wf/spec.json
@@ -1,125 +1,146 @@
 {
-    "ver": "1.4.0",
-    "authors": [
-        "dylan","msneddon","dparks","tgu2","seanjungbluth"
-    ],
-    "contact": "http://kbase.us/contact-us/",
-    "categories": ["active","communities","assembly"],
-    "widgets": {
-        "input": null,
-        "output": "no-display"
-    },
-    "parameters": [ 
+  "authors": [
+    "dylan",
+    "msneddon",
+    "dparks",
+    "tgu2",
+    "seanjungbluth",
+    "ialarmedalien"
+  ],
+  "behavior": {
+    "service-mapping": {
+      "input_mapping": [
         {
-            "id": "input_ref",
-            "optional": false,
-            "advanced": false,
-            "allow_multiple": false,
-            "default_values": [ "" ],
-            "field_type": "text",
-            "text_options": {
-                "valid_ws_types": [ "KBaseMetagenomes.BinnedContigs",
-				    "KBaseGenomeAnnotations.Assembly",
-				    "KBaseGenomes.ContigSet",
-				    "KBaseSets.AssemblySet",
-				    "KBaseGenomes.Genome",
-				    "KBaseSearch.GenomeSet"
-				  ]
-            }
-        }, 
+          "narrative_system_variable": "workspace",
+          "target_property": "workspace_name"
+        },
         {
-            "id": "reduced_tree",
-            "optional": false,
-            "advanced": true,
-            "allow_multiple": false,
-            "default_values":[1],
-            "field_type" : "dropdown",
-            "dropdown_options": {
-		"options": [
-		    {
-			"value": 1,
-			"display": "reduced tree",
-			"id": "reduced_tree_TRUE",
-			"ui-name": "reduced_tree_TRUE"
-		    },
-		    {
-			"value": 0,
-			"display": "full tree",
-			"id": "reduced_tree_FALSE",
-			"ui-name": "reduced_tree_FALSE"
-		    }
-		]
-            }
-        }, 
+          "input_parameter": "input_ref",
+          "target_property": "input_ref",
+          "target_type_transform": "resolved-ref"
+        },
         {
-           "id": "save_all_plots",
-            "optional": false,
-            "advanced": true,
-            "allow_multiple": false,
-            "default_values":[1],
-            "field_type" : "dropdown",
-            "dropdown_options": {
-		"options": [
-		    {
-			"value": 0,
-			"display": "discard",
-			"id": "save_all_plots_FALSE",
-			"ui-name": "save_all_plots_FALSE"
-		    },
-		    {
-			"value": 1,
-			"display": "save",
-			"id": "save_all_plots_TRUE",
-			"ui-name": "save_all_plots_TRUE"
-		    }
-		]
-            }
+          "input_parameter": "reduced_tree",
+          "target_property": "reduced_tree"
+        },
+        {
+          "input_parameter": "save_all_plots",
+          "target_property": "save_plots_dir"
+        },
+        {
+          "constant_value": "4",
+          "target_property": "threads"
         }
-    ],
-
-    "behavior": {
-        "service-mapping": {
-            "url": "",
-            "name": "kb_Msuite",
-            "method": "run_checkM_lineage_wf",
-            "input_mapping": [
-                {
-                    "narrative_system_variable": "workspace",
-                    "target_property": "workspace_name"
-                },
-                {
-                    "input_parameter": "input_ref",
-                    "target_property": "input_ref",
-                    "target_type_transform": "resolved-ref"
-                },
-                {
-                    "input_parameter": "reduced_tree",
-                    "target_property": "reduced_tree"
-                },
-                {
-                    "input_parameter": "save_all_plots",
-                    "target_property": "save_plots_dir"
-                },
-                {
-                    "constant_value": "4",
-                    "target_property": "threads"
-                }
-            ],
-            "output_mapping": [
-                {
-                    "service_method_output_path": [0, "report_name"],
-                    "target_property": "report_name"
-                },
-                {
-                    "service_method_output_path": [0, "report_ref"],
-                    "target_property": "report_ref"
-                },
-                {
-                    "constant_value": "36",
-                    "target_property": "report_window_line_height"
-                }
-            ]
+      ],
+      "method": "run_checkM_lineage_wf",
+      "name": "kb_Msuite",
+      "output_mapping": [
+        {
+          "service_method_output_path": [
+            0,
+            "report_name"
+          ],
+          "target_property": "report_name"
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "report_ref"
+          ],
+          "target_property": "report_ref"
+        },
+        {
+          "constant_value": "36",
+          "target_property": "report_window_line_height"
         }
+      ],
+      "url": ""
+    }
+  },
+  "categories": [
+    "active",
+    "communities",
+    "assembly"
+  ],
+  "contact": "http://kbase.us/contact-us/",
+  "job_id_output_field": "docker",
+  "parameters": [
+    {
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "id": "input_ref",
+      "optional": false,
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseMetagenomes.BinnedContigs",
+          "KBaseGenomeAnnotations.Assembly",
+          "KBaseGenomes.ContigSet",
+          "KBaseSets.AssemblySet",
+          "KBaseGenomes.Genome",
+          "KBaseSearch.GenomeSet"
+        ]
+      }
     },
-    "job_id_output_field": "docker"
+    {
+      "advanced": true,
+      "allow_multiple": false,
+      "default_values": [
+        1
+      ],
+      "dropdown_options": {
+        "options": [
+          {
+            "display": "reduced tree",
+            "id": "reduced_tree_TRUE",
+            "ui-name": "reduced_tree_TRUE",
+            "value": 1
+          },
+          {
+            "display": "full tree",
+            "id": "reduced_tree_FALSE",
+            "ui-name": "reduced_tree_FALSE",
+            "value": 0
+          }
+        ]
+      },
+      "field_type": "dropdown",
+      "id": "reduced_tree",
+      "optional": false
+    },
+    {
+      "advanced": true,
+      "allow_multiple": false,
+      "default_values": [
+        1
+      ],
+      "dropdown_options": {
+        "options": [
+          {
+            "display": "discard",
+            "id": "save_all_plots_FALSE",
+            "ui-name": "save_all_plots_FALSE",
+            "value": 0
+          },
+          {
+            "display": "save",
+            "id": "save_all_plots_TRUE",
+            "ui-name": "save_all_plots_TRUE",
+            "value": 1
+          }
+        ]
+      },
+      "field_type": "dropdown",
+      "id": "save_all_plots",
+      "optional": false
+    }
+  ],
+  "ver": "1.5.0",
+  "widgets": {
+    "input": null,
+    "output": "no-display"
+  }
 }

--- a/ui/narrative/methods/run_checkM_lineage_wf_withFilter/spec.json
+++ b/ui/narrative/methods/run_checkM_lineage_wf_withFilter/spec.json
@@ -1,178 +1,213 @@
 {
-    "ver": "1.4.0",
-    "authors": [
-        "dylan","msneddon","dparks","tgu2","seanjungbluth"
-    ],
-    "contact": "http://kbase.us/contact-us/",
-    "categories": ["active","communities","assembly"],
-    "widgets": {
-        "input": null,
-        "output": "no-display"
-    },
-    "parameters": [ 
+  "authors": [
+    "dylan",
+    "msneddon",
+    "dparks",
+    "tgu2",
+    "seanjungbluth",
+    "ialarmedalien"
+  ],
+  "behavior": {
+    "service-mapping": {
+      "input_mapping": [
         {
-            "id": "input_ref",
-            "optional": false,
-            "advanced": false,
-            "allow_multiple": false,
-            "default_values": [ "" ],
-            "field_type": "text",
-            "text_options": {
-                "valid_ws_types": [ "KBaseMetagenomes.BinnedContigs" ]
-            }
-        }, 
-        {
-            "id": "reduced_tree",
-            "optional": false,
-            "advanced": true,
-            "allow_multiple": false,
-            "default_values":[1],
-            "field_type" : "dropdown",
-            "dropdown_options": {
-		"options": [
-		    {
-			"value": 1,
-			"display": "reduced tree",
-			"id": "reduced_tree_TRUE",
-			"ui-name": "reduced_tree_TRUE"
-		    },
-		    {
-			"value": 0,
-			"display": "full tree",
-			"id": "reduced_tree_FALSE",
-			"ui-name": "reduced_tree_FALSE"
-		    }
-		]
-            }
-        }, 
-        {
-           "id": "save_all_plots",
-            "optional": false,
-            "advanced": true,
-            "allow_multiple": false,
-            "default_values":[1],
-            "field_type" : "dropdown",
-            "dropdown_options": {
-		"options": [
-		    {
-			"value": 0,
-			"display": "discard",
-			"id": "save_all_plots_FALSE",
-			"ui-name": "save_all_plots_FALSE"
-		    },
-		    {
-			"value": 1,
-			"display": "save",
-			"id": "save_all_plots_TRUE",
-			"ui-name": "save_all_plots_TRUE"
-		    }
-		]
-            }
+          "narrative_system_variable": "workspace",
+          "target_property": "workspace_name"
         },
         {
-            "id": "completeness_perc",
-            "optional": false,
-            "advanced": false,
-            "allow_multiple": false,
-            "default_values": [ "95" ],
-            "field_type": "text",
-            "text_options": {
-                "validate_as": "float",
-		"min_float": 0.0,
-		"max_float": 100.0
-            }
-        }, 
+          "input_parameter": "input_ref",
+          "target_property": "input_ref",
+          "target_type_transform": "resolved-ref"
+        },
         {
-            "id": "contamination_perc",
-            "optional": false,
-            "advanced": false,
-            "allow_multiple": false,
-            "default_values": [ "2" ],
-            "field_type": "text",
-            "text_options": {
-                "validate_as": "float",
-		"min_float": 0.0,
-		"max_float": 100.0
-            }
-        }, 
+          "input_parameter": "reduced_tree",
+          "target_property": "reduced_tree"
+        },
         {
-            "id": "output_filtered_binnedcontigs_obj_name",
-            "optional": false,
-            "advanced": false,
-            "allow_multiple": false,
-            "default_values": [ "CheckM_HQ_bins.BinnedContigs" ],
-            "field_type": "text",
-            "text_options": {
-                "valid_ws_types": [ "KBaseMetagenomes.BinnedContigs" ],
-		"is_output_name" : true
-            }
-        } 
-
-    ],
-
-    "behavior": {
-        "service-mapping": {
-            "url": "",
-            "name": "kb_Msuite",
-            "method": "run_checkM_lineage_wf_withFilter",
-            "input_mapping": [
-                {
-                    "narrative_system_variable": "workspace",
-                    "target_property": "workspace_name"
-                },
-                {
-                    "input_parameter": "input_ref",
-                    "target_property": "input_ref",
-                    "target_type_transform": "resolved-ref"
-                },
-                {
-                    "input_parameter": "reduced_tree",
-                    "target_property": "reduced_tree"
-                },
-                {
-                    "input_parameter": "save_all_plots",
-                    "target_property": "save_plots_dir"
-                },
-                {
-                    "input_parameter": "completeness_perc",
-                    "target_property": "completeness_perc"
-                },
-                {
-                    "input_parameter": "contamination_perc",
-                    "target_property": "contamination_perc"
-                },
-                {
-                    "input_parameter": "output_filtered_binnedcontigs_obj_name",
-                    "target_property": "output_filtered_binnedcontigs_obj_name"
-                },
-                {
-                    "constant_value": "4",
-                    "target_property": "threads"
-                }
-            ],
-            "output_mapping": [
-                {
-                    "service_method_output_path": [0, "report_name"],
-                    "target_property": "report_name"
-                },
-                {
-                    "service_method_output_path": [0, "report_ref"],
-                    "target_property": "report_ref"
-                },
-                {
-                    "service_method_output_path": [0, "binned_contig_obj_ref"],
-                    "target_property": "binned_contig_obj_ref"
-                },
-                {
-                    "service_method_output_path": [0, "binned_contig_obj_ref"],
-                    "target_property": "objRef"
-                },
-                {
-                    "constant_value": "36",
-                    "target_property": "report_window_line_height"
-                }
-            ]
+          "input_parameter": "save_all_plots",
+          "target_property": "save_plots_dir"
+        },
+        {
+          "input_parameter": "completeness_perc",
+          "target_property": "completeness_perc"
+        },
+        {
+          "input_parameter": "contamination_perc",
+          "target_property": "contamination_perc"
+        },
+        {
+          "input_parameter": "output_filtered_binnedcontigs_obj_name",
+          "target_property": "output_filtered_binnedcontigs_obj_name"
+        },
+        {
+          "constant_value": "4",
+          "target_property": "threads"
         }
+      ],
+      "method": "run_checkM_lineage_wf_withFilter",
+      "name": "kb_Msuite",
+      "output_mapping": [
+        {
+          "service_method_output_path": [
+            0,
+            "report_name"
+          ],
+          "target_property": "report_name"
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "report_ref"
+          ],
+          "target_property": "report_ref"
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "binned_contig_obj_ref"
+          ],
+          "target_property": "binned_contig_obj_ref"
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "binned_contig_obj_ref"
+          ],
+          "target_property": "objRef"
+        },
+        {
+          "constant_value": "36",
+          "target_property": "report_window_line_height"
+        }
+      ],
+      "url": ""
+    }
+  },
+  "categories": [
+    "active",
+    "communities",
+    "assembly"
+  ],
+  "contact": "http://kbase.us/contact-us/",
+  "job_id_output_field": "docker",
+  "parameters": [
+    {
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "id": "input_ref",
+      "optional": false,
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseMetagenomes.BinnedContigs"
+        ]
+      }
     },
-    "job_id_output_field": "docker"
+    {
+      "advanced": true,
+      "allow_multiple": false,
+      "default_values": [
+        1
+      ],
+      "dropdown_options": {
+        "options": [
+          {
+            "display": "reduced tree",
+            "id": "reduced_tree_TRUE",
+            "ui-name": "reduced_tree_TRUE",
+            "value": 1
+          },
+          {
+            "display": "full tree",
+            "id": "reduced_tree_FALSE",
+            "ui-name": "reduced_tree_FALSE",
+            "value": 0
+          }
+        ]
+      },
+      "field_type": "dropdown",
+      "id": "reduced_tree",
+      "optional": false
+    },
+    {
+      "advanced": true,
+      "allow_multiple": false,
+      "default_values": [
+        1
+      ],
+      "dropdown_options": {
+        "options": [
+          {
+            "display": "discard",
+            "id": "save_all_plots_FALSE",
+            "ui-name": "save_all_plots_FALSE",
+            "value": 0
+          },
+          {
+            "display": "save",
+            "id": "save_all_plots_TRUE",
+            "ui-name": "save_all_plots_TRUE",
+            "value": 1
+          }
+        ]
+      },
+      "field_type": "dropdown",
+      "id": "save_all_plots",
+      "optional": false
+    },
+    {
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        "95"
+      ],
+      "field_type": "text",
+      "id": "completeness_perc",
+      "optional": false,
+      "text_options": {
+        "max_float": 100.0,
+        "min_float": 0.0,
+        "validate_as": "float"
+      }
+    },
+    {
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        "2"
+      ],
+      "field_type": "text",
+      "id": "contamination_perc",
+      "optional": false,
+      "text_options": {
+        "max_float": 100.0,
+        "min_float": 0.0,
+        "validate_as": "float"
+      }
+    },
+    {
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        "CheckM_HQ_bins.BinnedContigs"
+      ],
+      "field_type": "text",
+      "id": "output_filtered_binnedcontigs_obj_name",
+      "optional": false,
+      "text_options": {
+        "is_output_name": true,
+        "valid_ws_types": [
+          "KBaseMetagenomes.BinnedContigs"
+        ]
+      }
+    }
+  ],
+  "ver": "1.5.0",
+  "widgets": {
+    "input": null,
+    "output": "no-display"
+  }
 }


### PR DESCRIPTION
This PR does not change the functionality, but puts in place some changes to make future work easier.

- Creating a new Docker image for ease of testing checkM, with the prerequisite binaries and python modules already installed. Saved to `ialarmedalien/kbase_checkm_base:latest`. `Dockerfile_checkM` creates this base image, and `Dockerfile` adds the local python directory on top. `Dockerfile` from the previous version has been renamed `Dockerfile_full`. Once the app updates and testing are complete, I will move the files back again.
- Adding self to `kbase.yml` author list.
- Switched the current assembly and genome queries to use smaller datasets to speed up tests.
- Ran json pretty print over the UI spec files since there was a mix of tabs and spaces ( :o ) and the keys were not ordered.